### PR TITLE
Add floating WhatsApp button example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # workflows-codex
+
+Este repositório contém exemplos e fluxos de automação.
+
+## Exemplo de Botão Flutuante do WhatsApp
+
+O arquivo `floating-whatsapp.html` demonstra como implementar um botão flutuante utilizando as cores padrão do WhatsApp.

--- a/floating-whatsapp.html
+++ b/floating-whatsapp.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Botão WhatsApp</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      height: 200vh; /* para testar o posicionamento flutuante */
+    }
+    .whatsapp-container {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      z-index: 1000;
+    }
+    .whatsapp-button {
+      background-color: #25D366; /* verde padrão do WhatsApp */
+      border-radius: 50%;
+      width: 60px;
+      height: 60px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+      text-decoration: none;
+    }
+    .whatsapp-button:hover {
+      box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+    }
+    .whatsapp-button svg {
+      width: 32px;
+      height: 32px;
+      fill: #fff; /* ícone branco */
+    }
+  </style>
+</head>
+<body>
+  <div class="whatsapp-container">
+    <a class="whatsapp-button" href="https://wa.me/5511999999999" target="_blank" aria-label="Fale conosco pelo WhatsApp">
+      <!-- ícone de telefone -->
+      <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <path d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16S24.837 0 16 0zm8.726 23.962c-.366 1.024-2.143 1.95-2.964 2.01-.757.05-1.676.07-2.7-.17-.616-.147-1.375-.446-2.38-.873-4.204-1.81-6.928-6.163-7.146-6.456-.208-.29-1.71-2.274-1.71-4.34s1.084-3.078 1.47-3.495c.384-.416.84-.52 1.12-.52.28 0 .56.003.804.014.26.013.614-.1.96.733.366.863 1.245 2.98 1.355 3.194.112.212.188.462.035.743-.256.476-.387.775-.764 1.247-.207.262-.434.587-.18 1.07.256.482 1.13 1.85 2.421 3 1.67 1.51 3.075 1.984 3.557 2.21.482.226.757.19 1.035-.113.28-.304 1.188-1.384 1.507-1.857.322-.476.64-.384 1.09-.23.45.152 2.848 1.34 3.332 1.584.485.244.806.366.92.57.115.204.115 1.188-.25 2.212z"/>
+      </svg>
+    </a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add example HTML for a floating WhatsApp button
- fix README heading and reference to the example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68896bb1564483219cf46eb86e418439